### PR TITLE
Fixed score computation for all transitions

### DIFF
--- a/eval_res.py
+++ b/eval_res.py
@@ -45,7 +45,7 @@ def eval(predict_path,gt_path):
             
             cut_correct=get_union_cnt(gt_cuts,predicts_cut)
             gradual_correct=get_union_cnt(gt_graduals,predicts_gradual)
-            all_correct=get_union_cnt(predicts_cut+predicts_gradual,_gts)
+            all_correct=get_union_cnt(_gts,predicts_cut+predicts_gradual)
 
             cut_correct_sum+=cut_correct
             gradual_correct_sum+=gradual_correct


### PR DESCRIPTION
The number of correct predictions for all the transitions (cut + gradual) was computed incorrectly, since the arguments of the get_union_cnt function were inverted. This could cause weird behaviour, such as a recall score > 1, since the predicted transitions were used as ground truth and vice versa.

This pull request should fix the issue.

(The same bug was reported and fixed in another pull request for the ClipShots repository: https://github.com/Tangshitao/ClipShots/pull/11)